### PR TITLE
Fix deprecation notice

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ module.exports = (options = {}) => (tree) => {
     return u(
       'html',
       toHTML(/^inline/.test(type) ? code : pre, {
-        allowDangerousHTML: true,
+        allowDangerousHtml: true,
       }),
     );
   });


### PR DESCRIPTION
Small little deprecation notice I saw from [hast-util-to-html](https://github.com/syntax-tree/hast-util-to-html/blob/main/lib/index.js#L22).

Should be a quick fix!