### PR TITLE
Add .npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.eslintignore
+.github
+.prettierignore
+.yarn
+.yarnrc.yml
+media
+test


### PR DESCRIPTION
This package is currently [10.7 MiB in size](https://packagephobia.com/result?p=remark-prism) inside of a `node_modules` folder. It ships all the tests, fixtures, a copy of Yarn and a photo, none of which are useful to users of this library. This diff resolves the issue by adding an `.npmignore` file, which reduces the size of the package to 0.03 MiB. The largest file is `CHANGELOG.md` which I left in the package, but could be removed too.

Thank you for considering this PR.