### PR TITLE
Docs/add section about line highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,50 @@ use(require('remark-prism'), {
 <pre class="language-diff-javascript diff-highlight line-numbers">...</pre>
 ```
 
+### line highlighting
+
+**Single line:**
+```
+\`\`\`javascript[class="line-numbers"]{3}
+```
+
+```html
+<pre class="language-javascript line-numbers">
+  <code>
+    <!-- The line to be highlighted -->
+    <span class="remark-highlight-code-line"> ...</span>
+  </code>
+</pre>
+```
+
+**Multiple line:**
+
+```
+\`\`\`javascript[class="line-numbers"]{3-5}
+```
+
+```html
+<pre class="language-javascript line-numbers">
+  <code>
+    <!-- The line to be highlighted -->
+    <span class="remark-highlight-code-line">...</span>
+    <span class="remark-highlight-code-line">...</span>
+    <span class="remark-highlight-code-line">...</span>
+  </code>
+</pre>
+```
+
+**Note:** style need to be added into the site for `.remark-highlight-code-line`, example:
+
+```css
+.remark-highlight-code-line {
+  display: block;
+  background-color: #38383629; // highlight background color
+  margin: 3px 0; // adjust spacing between blocks
+}
+
+```
+
 ## license
 
 BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ use(require('remark-prism'), {
 </pre>
 ```
 
-**Note:** style need to be added into the site for `.remark-highlight-code-line`, example:
+**Note:** highlighting styles need to be added into css file on the site for `.remark-highlight-code-line` class, example:
 
 ```css
 .remark-highlight-code-line {


### PR DESCRIPTION
Update the docs to add section about instructions on how to add line highlighting.

Proposed additions to the readme:


<img width="885" alt="Screen Shot 2021-10-15 at 4 50 59 PM" src="https://user-images.githubusercontent.com/9851316/137565244-ceeeefeb-28f3-4b5b-8087-467e434d561f.png">



