### PR TITLE
feat: add `highlight-keywords` to PLUGINS array

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -13,6 +13,7 @@ const PLUGINS = [
   'command-line',
   'data-uri-highlight',
   'diff-highlight',
+  'highlight-keywords',
   'inline-color',
   'keep-markup',
   'line-numbers',


### PR DESCRIPTION
Follows on from #306, adding `highlight-keywords` to the `PLUGINS` array in order to use allow the use of more granular styles.